### PR TITLE
change exec stdio on default

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var command =
 module.exports = function() {
   try {
     return (
-      exec(command, { stdio: ["inherit", "inherit", "ignore"] })
+      exec(command)
         .toString()
         .trim() === "ec2"
     );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "is-ec2",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Test if the current node process is running on AWS EC2",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Hi. In current version of module (1.0.2) exec of command in case of ec2 instance write 'ec2' in stdout. Such behaviour is critical for me, because I have wrong data in stdout because of 'ec2' string adding. If use default stdio for exec ('pipe') there isn't 'ec2' in stdout. I tested added changes locally and in ec2 instance, in first case function returns false, in second case it returns true. I will really appreciate if you merge this fix.